### PR TITLE
add fullscreen

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Changes values displayed in an item line.
 | `--[no-]user`       | Show or hide user name                                                                                  |
 | `--[no-]group`      | Show or hide group name                                                                                 |
 | `--time-type VALUE` | Set which time is displayed. VALUE: modified, accessed, changed. Default: modified                      |
+| `--[no-]fullscreen` | Enable or disable full screen mode. Previous screen is restored on quit.                                |
 
 ### Search Config
 

--- a/app/App.zig
+++ b/app/App.zig
@@ -48,6 +48,9 @@ pub const Config = struct {
     // Search config
     fuzzy_search: bool = true,
     ignore_case: bool = true,
+
+    // Viewport config
+    fullscreen: bool = false,
 };
 
 pub fn init(allocator: mem.Allocator, config: *Config) !Self {
@@ -67,6 +70,8 @@ pub fn deinit(self: *Self) void {
 
 pub fn run(self: *Self) !void {
     try self.state.preRun();
+    defer self.state.postRun() catch {};
+
     while (true) {
         try self.state.updateViewport();
         try self.state.fillBuffer();
@@ -74,12 +79,15 @@ pub fn run(self: *Self) !void {
         try self.state.printContents();
 
         const action = try self.state.getAppAction();
+
         switch (action) {
-            .quit => return,
+            .quit => break,
             .no_action => continue,
             else => try self.state.executeAction(action),
         }
 
-        if (try self.state.dumpStdout()) return;
+        if (self.state.stdout.items.len > 0) {
+            break;
+        }
     }
 }

--- a/app/State.zig
+++ b/app/State.zig
@@ -350,8 +350,10 @@ pub fn appendOne(self: *Self) !bool {
 }
 
 pub fn dumpStdout(self: *Self) !void {
-    self.output.writer.unbuffered();
-    try self.output.draw.clearLinesBelow(self.viewport.start_row);
+    if (!self.fullscreen) {
+        self.output.writer.unbuffered();
+        try self.output.draw.clearLinesBelow(self.viewport.start_row);
+    }
 
     _ = try std.io.getStdOut().writer().write(self.stdout.items);
 }

--- a/app/State.zig
+++ b/app/State.zig
@@ -49,6 +49,9 @@ pre_search_cursor: usize,
 fuzzy_search: bool,
 ignore_case: bool,
 
+// Viewport config
+fullscreen: bool,
+
 allocator: mem.Allocator,
 
 const Self = @This();
@@ -89,6 +92,8 @@ pub fn init(allocator: mem.Allocator, config: *Config) !Self {
         .fuzzy_search = config.fuzzy_search,
         .ignore_case = config.ignore_case,
 
+        .fullscreen = config.fullscreen,
+
         .allocator = allocator,
     };
 }
@@ -119,9 +124,25 @@ pub fn deinit(self: *Self) void {
 }
 
 pub fn preRun(self: *Self) !void {
+    if (self.fullscreen) {
+        self.output.writer.unbuffered();
+        try self.output.draw.enableAlternateBuffer();
+        try self.output.draw.clearScreen();
+    }
+
     try self.viewport.initBounds();
     _ = try self.manager.root.children();
     self.reiterate = true;
+}
+
+pub fn postRun(self: *Self) !void {
+    if (self.fullscreen) {
+        try self.output.draw.disableAlternateBuffer();
+    }
+
+    if (self.stdout.items.len > 0) {
+        try self.dumpStdout();
+    }
 }
 
 pub fn updateViewport(self: *Self) !void {
@@ -328,11 +349,9 @@ pub fn appendOne(self: *Self) !bool {
     return true;
 }
 
-pub fn dumpStdout(self: *Self) !bool {
-    if (self.stdout.items.len == 0) return false;
+pub fn dumpStdout(self: *Self) !void {
     self.output.writer.unbuffered();
     try self.output.draw.clearLinesBelow(self.viewport.start_row);
 
     _ = try std.io.getStdOut().writer().write(self.stdout.items);
-    return true;
 }

--- a/app/args.zig
+++ b/app/args.zig
@@ -102,6 +102,13 @@ fn ConfigIterator(Iterator: type) type {
                     config.fuzzy_search = false;
                 } else if (eql(arg, "--match-case")) {
                     config.ignore_case = false;
+                }
+
+                // Viewport args
+                else if (eql(arg, "--fullscreen")) {
+                    config.fullscreen = true;
+                } else if (eql(arg, "--no-fullscreen")) {
+                    config.fullscreen = false;
                 } else if (from_env) {
                     continue;
                 }

--- a/app/help.zig
+++ b/app/help.zig
@@ -75,6 +75,10 @@ const help = [_]Section{
                 .key = "--time-type VALUE",
                 .description = "Set which time is displayed [(modified)|accessed|changed]",
             },
+            .{
+                .key = "--[no-]fullscreen",
+                .description = "Enable or disable fullscreen mode",
+            },
         },
     },
     .{

--- a/tui/Draw.zig
+++ b/tui/Draw.zig
@@ -239,6 +239,14 @@ pub fn disableAutowrap(self: *Self) !void {
     _ = try self.writer.write("\x1b[?7l");
 }
 
+pub fn enableAlternateBuffer(self: *Self) !void {
+    _ = try self.writer.write("\x1b[?1049h");
+}
+
+pub fn disableAlternateBuffer(self: *Self) !void {
+    _ = try self.writer.write("\x1b[?1049l");
+}
+
 /// Clear the screen and set cursor to the top left position.
 pub fn clearScreen(self: *Self) !void {
     _ = try self.writer.write("\x1b[2J\x1b[H");


### PR DESCRIPTION
Adds a `--[no-]fullscreen` flag that allows fex to to use the entire viewport. Contents of terminal are restored on quitting.

Closes #9 