### PR TITLE
adding function for binding fex to ctrl+f in fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ the shell you use.
 
 ### Zsh Setup
 
-To setup the Zsh widget for fex, first copy the file `shell/.fex.zsh` to your
+To setup the Zsh widget for fex, first copy the file [`shell/.fex.zsh`](./shell/.fex.zsh) to your
 home directory. Then copy the following lines into your `.zshrc`:
 
 ```bash
@@ -158,6 +158,10 @@ home directory. Then copy the following lines into your `.zshrc`:
 # Bind CTRL-F to invoke fex (key binds can be custom)
 bindkey '^f' fex-widget
 ```
+
+### Fish Setup 
+
+To setup the keybind on Fish, copy the code from [`shell/.fex.fish`](./shell/.fex.fish) into to your `$HOME/.config/fish/config.fish`. And restart your shell to see it working!
 
 > [!TIP]
 >

--- a/shell/.fex.fish
+++ b/shell/.fex.fish
@@ -1,5 +1,26 @@
-function launch_fex_on_ctrlf
-  'fex'
+# Sets up a fish widget
+
+function fex-launch-widget -d "Launch fex on ^f"
+
+  # setting global variable for fex
+  set -g FEX_COMMAND fex 
+
+  # execute and capture output of $FEX_COMMAND in exec_cmd
+  set exec_cmd (eval $FEX_COMMAND)
+  
+  # inary on fex
+  if test -z "$exec_cmd"
+    commandline -f repaint
+    return
+  end 
+
+  eval $exec_cmd 
+
+  # cleaning after execution 
+  commandline -f repaint
 end
 
-bind \cf launch_fex_on_ctrlf
+bind \cf fex-launch-widget
+# Ref's
+# What is eval ? - https://fishshell.com/docs/current/cmds/eval.html
+# https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish 

--- a/shell/.fex.fish
+++ b/shell/.fex.fish
@@ -1,26 +1,27 @@
 # Sets up a fish widget
 
 function fex-launch-widget -d "Launch fex on ^f"
-
-  # setting global variable for fex
-  set -g FEX_COMMAND fex 
+  # setting variable for fex
+  set -g FEX_COMMAND fex  
 
   # execute and capture output of $FEX_COMMAND in exec_cmd
   set exec_cmd (eval $FEX_COMMAND)
-  
-  # inary on fex
+
   if test -z "$exec_cmd"
     commandline -f repaint
     return
-  end 
-
-  eval $exec_cmd 
-
-  # cleaning after execution 
+  else 
+    # print the command which will be executed
+    echo $exec_cmd
+    eval $exec_cmd
+  end
+  
+  # cleaning after execution (jump to prompt on newline)
   commandline -f repaint
 end
 
 bind \cf fex-launch-widget
+
 # Ref's
 # What is eval ? - https://fishshell.com/docs/current/cmds/eval.html
 # https://github.com/junegunn/fzf/blob/master/shell/key-bindings.fish 

--- a/shell/.fex.fish
+++ b/shell/.fex.fish
@@ -1,0 +1,5 @@
+function launch_fex_on_ctrlf
+  'fex'
+end
+
+bind \cf launch_fex_on_ctrlf


### PR DESCRIPTION
Unlike ZSH idk why getting this done in fish felt easier. The setup is pretty straight forward, I read through some fish documentations and made a function to invoke fex on ctrl + f. I have added the function in a separate .fex.fish file and have updated the README. 

The configuration works very well and its breeze to use fex with ctrl +f now :). Please try it out.

Please let me know, if I'm making any dumb mistake. IMO, i'd like to also work on automating this by identifying users default shell and adding these configurations accordingly without them having to do any manual steps :).

Thank You