### PR TITLE
Printing the command before execution

### DIFF
--- a/shell/.fex.fish
+++ b/shell/.fex.fish
@@ -1,4 +1,4 @@
-# Sets up a fish widget
+# Sets up a fish widget to invoke on Ctrl-F 
 
 function fex-widget -d "Invokes fex and executes commands from it"
   # setting variable for fex
@@ -10,15 +10,18 @@ function fex-widget -d "Invokes fex and executes commands from it"
   if test -z "$exec_cmd"
     commandline -f repaint
     return
-  else 
-    # print the command which will be executed
-    echo $exec_cmd
-    eval $exec_cmd
+  else
+    commandline -f repaint
+    # if the $exec_Cmd printed, it prints both the parts (command) and (argument/flag) on new line. So. So, it needs to be joint. `
+    set joint_cmd (string join " " $exec_cmd)
+    commandline $joint_cmd
+    commandline -f execute
   end
-  
-  # cleaning after execution (jump to prompt on newline)
+
+  # cleaning after execution
   commandline -f repaint
 end
+
 
 # Ref's
 # What is eval ? - https://fishshell.com/docs/current/cmds/eval.html


### PR DESCRIPTION
Hello, 

In the previous PR #11, I wasn't able to figure out how to print the command which will be executed from Fex stdout. After I posted my write up blog on reddit and fishshell matrix. Folks there told me about ```commandline -f execute```. I knew about this before (not much of brief info) but I somehow ignored it. Yesterday, I gave it a shot and got to know that ```commandline -f execute``` executes from BUFFER, just like how ```zle accept-line``` does. 

How the current changes work: 

```fish
  else
    commandline -f repaint
    # if the $exec_cmd printed, it prints both the parts (command) and (argument/flag) on new line. So. So, it needs to be joint. `
    set joint_cmd (string join " " $exec_cmd)
    commandline $joint_cmd
    commandline -f execute
end
```

- $exec_cmd holds the value which comes from fex stdout, but the value is split as in for example:
```sh 
cd
$directory
```
- Hence, string command in fish is used to join both of them. 
- ```commandline -f $joint_cmd``` sets the current value of commandline to the value of $joint_cmd and is further executed with the function `execute`. 
   
Hence, this PR fixes the issue which we did not completely fix in #11. 

[bruh.webm](https://github.com/user-attachments/assets/3b274c8b-99ea-4f3c-ba2f-15a1109a218b)
