### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ quick exploration and navigation in mind.
 By using Vim-like keybindings, `fex` ends up being a near-effortless
 tool to zip around a file system:
 
-- `j`, `k` to move to the pervious and next item
+- `j`, `k` to move to the previous and next item
 - `h`, `l` to move up or drop down a directory
 - `/` to search for items
 - `:` to run commands on the selected item
@@ -49,7 +49,7 @@ tool to zip around a file system:
   - [Command Mode Controls](#command-mode-controls)
   - [Display Toggle Controls](#display-toggle-controls)
   - [Sort Controls](#sort-controls)
-- [Platorm Support](#platform-support)
+- [Platform Support](#platform-support)
 
 ## Installation
 

--- a/app/View.zig
+++ b/app/View.zig
@@ -1,4 +1,4 @@
-/// View is responsible for maintaing View.buffer which is an
+/// View is responsible for maintaining View.buffer which is an
 /// ArrayList of fs items to be displayed.
 ///
 /// It maintains the cursor, and first and last incices to keep

--- a/app/Viewport.zig
+++ b/app/Viewport.zig
@@ -124,7 +124,7 @@ fn updateMaxRows(self: *Self) void {
 }
 
 fn scrollAndSetCursor(lines: u16, row: u16, col: u16) !void {
-    // Scroll up and set cursor postion
+    // Scroll up and set cursor position
     var obuf: [64]u8 = undefined;
     const slc = try std.fmt.bufPrint(
         &obuf,
@@ -135,7 +135,7 @@ fn scrollAndSetCursor(lines: u16, row: u16, col: u16) !void {
 }
 
 fn setCursor(row: u16, col: u16) !void {
-    // Scroll up and set cursor postion
+    // Scroll up and set cursor position
     var obuf: [64]u8 = undefined;
     const slc = try std.fmt.bufPrint(
         &obuf,

--- a/fs/Stat.zig
+++ b/fs/Stat.zig
@@ -77,7 +77,7 @@ pub fn stat(abspath: []const u8) !Self {
         };
     }
 
-    // if not linux, defaul to libc impl of lstat
+    // if not linux, default to libc impl of lstat
     else {
         var statbuf: libc.struct_stat = undefined;
         if (libc.lstat(abspath_w, &statbuf) != 0) {

--- a/tui/Draw.zig
+++ b/tui/Draw.zig
@@ -68,7 +68,7 @@ const BoxConfig = struct {
     height: usize = 4, // number of vertical border chars, if 0 then only vertices
     chars: BoxChars = .{},
     styles: BoxStyles = .{},
-    style: []const u8 = "", // common style, overriden if `styles.value` is set.
+    style: []const u8 = "", // common style, overridden if `styles.value` is set.
 };
 
 // writer: fs.File.Writer,


### PR DESCRIPTION
Found via `codespell -L edn`